### PR TITLE
Update installation guide for pip to pip3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ It speaks the Printer Job Language (PJL) over the raw network "protocol"
 
 ## Installation
 1. `virtualenv venv && source ./venv/bin/activate` (optional)
-1. `pip install -r requirements.txt`
+1. `pip3 install -r requirements.txt`
 1. `python3 ./server.py`
 
 ## Usage


### PR DESCRIPTION
"pip3 install -r requirements.txt" instead of "pip install -r requirements.txt" as it's python3.